### PR TITLE
Fix #141 Type definition mismatch in extract euclidean header with implementation

### DIFF
--- a/segmatch/include/segmatch/segmenters/euclidean_segmenter.hpp
+++ b/segmatch/include/segmatch/segmenters/euclidean_segmenter.hpp
@@ -45,7 +45,7 @@ class EuclideanSegmenter : public Segmenter<ClusteredPointT> {
   /// operations. The first ID in each pair is the renamed segments, the second ID is the new
   /// segment ID.
   void segment(const PointNormals& normals, const std::vector<bool>& is_point_modified,
-               ClusteredCloud& cloud, PointsNeighborsProvider<MapPoint>& points_neighbors_provider,
+               ClusteredCloud& cloud, PointsNeighborsProvider<ClusteredPointT>& points_neighbors_provider,
                SegmentedCloud& segmented_cloud, std::vector<Id>& cluster_ids_to_segment_ids,
                std::vector<std::pair<Id, Id>>& renamed_segments) override;
 

--- a/segmatch/include/segmatch/segmenters/impl/euclidean_segmenter.hpp
+++ b/segmatch/include/segmatch/segmenters/impl/euclidean_segmenter.hpp
@@ -29,7 +29,7 @@ EuclideanSegmenter<ClusteredPointT>::EuclideanSegmenter(
 template<typename ClusteredPointT>
 void EuclideanSegmenter<ClusteredPointT>::segment(
     const PointNormals& normals, const std::vector<bool>& is_point_modified, ClusteredCloud& cloud,
-    PointsNeighborsProvider<MapPoint>& points_neighbors_provider, SegmentedCloud& segmented_cloud,
+    PointsNeighborsProvider<ClusteredPointT>& points_neighbors_provider, SegmentedCloud& segmented_cloud,
     std::vector<Id>& cluster_ids_to_segment_ids,
     std::vector<std::pair<Id, Id>>& renamed_segments) {
   BENCHMARK_BLOCK("SM.Worker.Segmenter");


### PR DESCRIPTION
Fixes #141

Hi,
Since MapPoint in segment implementation did not match the one in header, there was definition type error.


> /home/bruno/segmap_ws/src/segmap/segmatch/include/segmatch/segmenters/segmenter.hpp:40:16: note:        void segmatch::Segmenter<ClusteredPointT>::segment(const Poin
> tNormals&, const std::vector<bool>&, segmatch::Segmenter<ClusteredPointT>::ClusteredCloud&, segmatch::PointsNeighborsProvider<PointT>&, segmatch::SegmentedCloud&, st
> d::vector<long int>&, std::vector<std::pair<long int, long int> >&) [with ClusteredPointT = pcl::PointXYZ; segmatch::PointNormals = pcl::PointCloud<pcl::Normal>; seg
> match::Segmenter<ClusteredPointT>::ClusteredCloud = pcl::PointCloud<pcl::PointXYZ>]
>    virtual void segment(const PointNormals& normals, const std::vector<bool>& is_point_modified,
>                 ^
> /home/bruno/segmap_ws/src/segmap/segmenter/src/segmenter_tree.cpp:60:32: error: no matching function for call to ‘segmatch::EuclideanSegmenter<pcl::PointXYZ>::segmen
> t(segmatch::PointNormals&, std::vector<bool>&, pcl::PointCloud<pcl::PointXYZ>&, segmatch::KdTreePointsNeighborsProvider<pcl::PointXYZ>&, segmatch::SegmentedCloud&, s
> td::vector<long int>&, std::vector<std::pair<long int, long int> >&)’
>                 renamed_segments);
>                                 ^
> In file included from /home/bruno/segmap_ws/src/segmap/segmenter/src/segmenter_tree.cpp:3:0:
> /home/bruno/segmap_ws/src/segmap/segmatch/include/segmatch/segmenters/impl/euclidean_segmenter.hpp:30:6: note: candidate: void segmatch::EuclideanSegmenter<Clustered
> PointT>::segment(const PointNormals&, const std::vector<bool>&, segmatch::EuclideanSegmenter<ClusteredPointT>::ClusteredCloud&, segmatch::PointsNeighborsProvider<_Se
> gMatch_PointExtended>&, segmatch::SegmentedCloud&, std::vector<long int>&, std::vector<std::pair<long int, long int> >&) [with ClusteredPointT = pcl::PointXYZ; segma
> tch::PointNormals = pcl::PointCloud<pcl::Normal>; segmatch::EuclideanSegmenter<ClusteredPointT>::ClusteredCloud = pcl::PointCloud<pcl::PointXYZ>]
>  void EuclideanSegmenter<ClusteredPointT>::segment(
>       ^
> /home/bruno/segmap_ws/src/segmap/segmatch/include/segmatch/segmenters/impl/euclidean_segmenter.hpp:30:6: note:   no known conversion for argument 4 from ‘segmatch::K
> dTreePointsNeighborsProvider<pcl::PointXYZ>’ to ‘segmatch::PointsNeighborsProvider<_SegMatch_PointExtended>&’
> make[2]: *** [CMakeFiles/segmenter.dir/src/segmenter_tree.cpp.o] Error 1
> make[1]: *** [CMakeFiles/segmenter.dir/all] Error 2

Regards,
Bruno